### PR TITLE
Fix for customParameters variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,4 +159,26 @@ export.config = {
     // ...
 }
 ```
+
+### customParameters
+Parameters which will be added to the re-run command that is generated.
+Can be used with `commandPrefix`.
+
+Type: `String`
+
+Default: `''`
+
+Example:
+```js
+const RerunService = require('wdio-rerun-service');
+export.config = {
+    // ...
+    services: [
+        [RerunService, {
+            customParameters: "--foobar"
+        }]
+    ],
+    // ...
+}
+```
 ----

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ class RerunService {
         if (fs.existsSync(directoryPath)) {
             const rerunFiles = fs.readdirSync(directoryPath);
             if (rerunFiles.length > 0) {
-                let rerunCommand = `${this.commandPrefix} DISABLE_RERUN=true node_modules/.bin/wdio ${this.customParameters} ${argv._[0]} `;
+                let rerunCommand = `${this.commandPrefix} DISABLE_RERUN=true node_modules/.bin/wdio ${argv._[0]} ${this.customParameters} `;
                 let failureLocations = [];
                 rerunFiles.forEach(file => {
                     const json = JSON.parse(fs.readFileSync(`${this.rerunDataDir}/${file}`));

--- a/src/index.js
+++ b/src/index.js
@@ -6,13 +6,14 @@ const argv = require('minimist')(process.argv.slice(2));
 
 class RerunService {
 
-    constructor({ ignoredTags, rerunDataDir, rerunScriptPath, commandPrefix } = {}) {
+    constructor({ ignoredTags, rerunDataDir, rerunScriptPath, commandPrefix, customParameters } = {}) {
         this.nonPassingItems = [];
         this.serviceWorkerId;
-        this.ignoredTags = ignoredTags ? ignoredTags : [];
-        this.rerunDataDir = rerunDataDir ? rerunDataDir : "./results/rerun";
-        this.rerunScriptPath = rerunScriptPath ? rerunScriptPath : "./rerun.sh";
-        this.commandPrefix = commandPrefix ? commandPrefix : "";
+        this.ignoredTags = ignoredTags || [];
+        this.rerunDataDir = rerunDataDir || "./results/rerun";
+        this.rerunScriptPath = rerunScriptPath || "./rerun.sh";
+        this.commandPrefix = commandPrefix || "";
+        this.customParameters = customParameters || "";
         this.specFile = "";
     }
 
@@ -73,10 +74,7 @@ class RerunService {
         if (fs.existsSync(directoryPath)) {
             const rerunFiles = fs.readdirSync(directoryPath);
             if (rerunFiles.length > 0) {
-                let rerunCommand = `DISABLE_RERUN=true node_modules/.bin/wdio ${argv._[0]} `;
-                if (this.commandPrefix) {
-                    rerunCommand = `${this.commandPrefix} ${rerunCommand}`;
-                }
+                let rerunCommand = `${this.commandPrefix} DISABLE_RERUN=true node_modules/.bin/wdio ${this.customParameters} ${argv._[0]} `;
                 let failureLocations = [];
                 rerunFiles.forEach(file => {
                     const json = JSON.parse(fs.readFileSync(`${this.rerunDataDir}/${file}`));

--- a/tests/service.test.js
+++ b/tests/service.test.js
@@ -48,6 +48,7 @@ describe('wdio-rerurn-service', () => {
         expect(service.rerunDataDir).toEqual("./results/rerun");
         expect(service.rerunScriptPath).toEqual("./rerun.sh");
         expect(service.commandPrefix).toEqual("");
+        expect(service.customParameters).toEqual("");
     })
 
     it('should throw error when setup bad rereunDataDir', () => {
@@ -62,6 +63,7 @@ describe('wdio-rerurn-service', () => {
         expect(service.rerunDataDir).toEqual("./results/rerun");
         expect(service.rerunScriptPath).toEqual("./rerun.sh");
         expect(service.commandPrefix).toEqual("");
+        expect(service.customParameters).toEqual("");
     })
 
     it('can configure rerunDataDir', () => {
@@ -71,6 +73,7 @@ describe('wdio-rerurn-service', () => {
         expect(service.rerunDataDir).toEqual("./results/custom_rerun_directory");
         expect(service.rerunScriptPath).toEqual("./rerun.sh");
         expect(service.commandPrefix).toEqual("");
+        expect(service.customParameters).toEqual("");
     })
 
     it('can configure rerunScriptPath', () => {
@@ -80,6 +83,7 @@ describe('wdio-rerurn-service', () => {
         expect(service.rerunDataDir).toEqual("./results/rerun");
         expect(service.rerunScriptPath).toEqual("./custom_rerun_script.sh");
         expect(service.commandPrefix).toEqual("");
+        expect(service.customParameters).toEqual("");
     })
 
     it('can configure commandPrefix', () => {
@@ -89,6 +93,17 @@ describe('wdio-rerurn-service', () => {
         expect(service.rerunDataDir).toEqual("./results/rerun");
         expect(service.rerunScriptPath).toEqual("./rerun.sh");
         expect(service.commandPrefix).toEqual("CUSTOM_VAR=true");
+        expect(service.customParameters).toEqual("");
+    })
+
+    it('can configure customParameters', () => {
+        let service = new RerunService({customParameters: "--foobar"});
+        expect(() => service.before({}, ['features/sample.feature'])).not.toThrow();
+        expect(service.ignoredTags).toEqual([]);
+        expect(service.rerunDataDir).toEqual("./results/rerun");
+        expect(service.rerunScriptPath).toEqual("./rerun.sh");
+        expect(service.commandPrefix).toEqual("");
+        expect(service.customParameters).toEqual("--foobar");
     })
 
     it('before should throw an exception when no parameters are given', () => {
@@ -113,7 +128,7 @@ describe('wdio-rerurn-service', () => {
         expect(() => service.afterScenario()).toThrow();
     })
 
-    it('afterScenario should mot throw an exception when parameters are given', () => {
+    it('afterScenario should not throw an exception when parameters are given', () => {
         let service = new RerunService();
         global.browser = cucumberBrowser;
         expect(() => service.afterScenario(world)).not.toThrow();
@@ -127,8 +142,14 @@ describe('wdio-rerurn-service', () => {
         expect(() => service.after()).not.toThrow();
     })
 
-    it('onComplete should throw an exception when no parameters are given', () => {
+    it('onComplete should throw an exception when no parameters are given with prefix', () => {
         let service = new RerunService({commandPrefix: "CUSTOM_VAR=true"});
+        service.nonPassingItems = nonPassingItems;
+        expect(() => service.onComplete()).not.toThrow();
+    })
+
+    it('onComplete should throw an exception when no parameters are given with additional params', () => {
+        let service = new RerunService({customParameters: "--foobar"});
         service.nonPassingItems = nonPassingItems;
         expect(() => service.onComplete()).not.toThrow();
     })


### PR DESCRIPTION
**Issue**:
customParameters variable inserted in wrong place of rerun command:

**Actual**: ` DISABLE_RERUN=true node_modules/.bin/wdio --foobar ./config/wdio.conf.js .../service.test.js  --spec=feature/sample.feature:1 --spec=feature/sample.feature:4`
**Expected**: ` DISABLE_RERUN=true node_modules/.bin/wdio ./config/wdio.conf.js --foobar .../service.test.js  --spec=feature/sample.feature:1 --spec=feature/sample.feature:4`