### PR TITLE
Custom parameter command position fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ class RerunService {
         if (fs.existsSync(directoryPath)) {
             const rerunFiles = fs.readdirSync(directoryPath);
             if (rerunFiles.length > 0) {
-                let rerunCommand = `${this.commandPrefix} DISABLE_RERUN=true node_modules/.bin/wdio ${this.customParameters} ${argv._[0]} `;
+                let rerunCommand = `${this.commandPrefix} DISABLE_RERUN=true node_modules/.bin/wdio ${argv._[0]} ${this.customParameters} `;
                 let failureLocations = [];
                 rerunFiles.forEach(file => {
                     const json = JSON.parse(fs.readFileSync(`${this.rerunDataDir}/${file}`));


### PR DESCRIPTION
**Issue**:
customParameters variable inserted in wrong place of rerun command:

**Actual**: 

`DISABLE_RERUN=true node_modules/.bin/wdio --foobar ./config/wdio.conf.js .../service.test.js --spec=feature/sample.feature:1 --spec=feature/sample.feature:4`

**Expected**: 

`DISABLE_RERUN=true node_modules/.bin/wdio ./config/wdio.conf.js --foobar .../service.test.js --spec=feature/sample.feature:1 --spec=feature/sample.feature:4`
