### PR TITLE
Fix rerun script for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ results/
 .idea/
 .vscode/
 rerun.sh
+rerun.bat

--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,8 @@ tests/
 coverage/
 .idea/
 results/
+rerun.sh
+rerun.bat
 tsconfig.json
 tsconfig.eslint.json
 .eslintrc.json

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepare": "npm run build",
     "rename:cjs": "shx mv ./build/cjs/index.js ./build/index.cjs && rimraf ./build/cjs",
     "test": "run-s test:*",
-    "test:clean": "rimraf ./results ./coverage rerun.sh",
+    "test:clean": "rimraf ./results ./coverage rerun.sh rerun.bat",
     "test:eslint": "eslint src tests",
     "test:tsc": "tsc -p tsconfig.json --noEmit",
     "test:unit": "jest --collectCoverageFrom='[\"src/**/*.{js,jsx,ts,tsx}\"]' --coverage --collectCoverage=true --forceExit --detectOpenHandles tests/.*test.*",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import type { Testrunner } from '@wdio/types/build/Options'
 import minimist from 'minimist'
 import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { argv } from 'node:process'
+import { argv, platform } from 'node:process'
 import { v5 as uuidv5 } from 'uuid'
 
 type AfterScenario = NonNullable<
@@ -47,7 +47,8 @@ export default class RerunService implements Services.ServiceInstance {
         this.serviceWorkerId = ''
         this.ignoredTags = ignoredTags ?? []
         this.rerunDataDir = rerunDataDir ?? './results/rerun'
-        this.rerunScriptPath = rerunScriptPath ?? './rerun.sh'
+        this.rerunScriptPath =
+            rerunScriptPath ?? (platform === 'win32' ? 'rerun.bat' : 'rerun.sh')
         this.commandPrefix = commandPrefix ?? ''
         this.customParameters = customParameters ?? ''
         this.specFile = ''
@@ -152,7 +153,11 @@ export default class RerunService implements Services.ServiceInstance {
             const parsedArgs = minimist(argv.slice(2))
             const args = parsedArgs._[0] ? parsedArgs._[0] + ' ' : ''
             const prefix = this.commandPrefix ? this.commandPrefix + ' ' : ''
-            let rerunCommand = `${prefix}DISABLE_RERUN=true node_modules/.bin/wdio ${args}${this.customParameters}`
+            const disableRerun =
+                platform === 'win32'
+                    ? 'set DISABLE_RERUN=true &&'
+                    : 'DISABLE_RERUN=true'
+            let rerunCommand = `${prefix}${disableRerun} npx wdio ${args}${this.customParameters}`
             const failureLocations = new Set<string>()
             for (const file of rerunFiles) {
                 const json = JSON.parse(
@@ -165,7 +170,7 @@ export default class RerunService implements Services.ServiceInstance {
             failureLocations.forEach((failureLocation) => {
                 rerunCommand += ` --spec=${failureLocation}`
             })
-            await writeFile(this.rerunScriptPath, rerunCommand)
+            await writeFile(this.rerunScriptPath, rerunCommand, { mode: 0o755 })
             // console.log(`Re-run script has been generated @ ${this.rerunScriptPath}`);
         } catch (err) {
             // console.log(`Re-run service failed to generate re-run script: ${err}`);

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from '@jest/globals'
 import minimist from 'minimist'
 import { readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { argv } from 'node:process'
+import { argv, platform } from 'node:process'
 import { join } from 'path'
 import RerunService from '../src'
 import { gherkinDocument, pickle } from './fixtures/cucumber'
@@ -34,6 +34,8 @@ describe('wdio-rerun-service', () => {
     const cucumberBrowser = { config: { framework: 'cucumber' } }
     const mochaBrowser = { config: { framework: 'mocha' } }
 
+    const rerunScriptFile = platform === 'win32' ? 'rerun.bat' : 'rerun.sh'
+
     describe('setup', () => {
         it('should not throw error when setup with no parameters', async () => {
             const service = new RerunService()
@@ -42,7 +44,7 @@ describe('wdio-rerun-service', () => {
             ).resolves.toBeUndefined()
             expect(service.ignoredTags).toEqual([])
             expect(service.rerunDataDir).toEqual('./results/rerun')
-            expect(service.rerunScriptPath).toEqual('./rerun.sh')
+            expect(service.rerunScriptPath).toEqual(rerunScriptFile)
             expect(service.commandPrefix).toEqual('')
             expect(service.customParameters).toEqual('')
         })
@@ -61,7 +63,7 @@ describe('wdio-rerun-service', () => {
             ).resolves.toBeUndefined()
             expect(service.ignoredTags).toEqual(['@ignored'])
             expect(service.rerunDataDir).toEqual('./results/rerun')
-            expect(service.rerunScriptPath).toEqual('./rerun.sh')
+            expect(service.rerunScriptPath).toEqual(rerunScriptFile)
             expect(service.commandPrefix).toEqual('')
             expect(service.customParameters).toEqual('')
         })
@@ -77,7 +79,7 @@ describe('wdio-rerun-service', () => {
             expect(service.rerunDataDir).toEqual(
                 './results/custom_rerun_directory',
             )
-            expect(service.rerunScriptPath).toEqual('./rerun.sh')
+            expect(service.rerunScriptPath).toEqual(rerunScriptFile)
             expect(service.commandPrefix).toEqual('')
             expect(service.customParameters).toEqual('')
         })
@@ -105,7 +107,7 @@ describe('wdio-rerun-service', () => {
             ).resolves.toBeUndefined()
             expect(service.ignoredTags).toEqual([])
             expect(service.rerunDataDir).toEqual('./results/rerun')
-            expect(service.rerunScriptPath).toEqual('./rerun.sh')
+            expect(service.rerunScriptPath).toEqual(rerunScriptFile)
             expect(service.commandPrefix).toEqual('CUSTOM_VAR=true')
             expect(service.customParameters).toEqual('')
         })
@@ -117,7 +119,7 @@ describe('wdio-rerun-service', () => {
             ).resolves.toBeUndefined()
             expect(service.ignoredTags).toEqual([])
             expect(service.rerunDataDir).toEqual('./results/rerun')
-            expect(service.rerunScriptPath).toEqual('./rerun.sh')
+            expect(service.rerunScriptPath).toEqual(rerunScriptFile)
             expect(service.commandPrefix).toEqual('')
             expect(service.customParameters).toEqual('--foobar')
         })
@@ -313,17 +315,21 @@ describe('wdio-rerun-service', () => {
 
         it('should add failed specs to rerun script', async () => {
             const rerunDataDir = join(tmpdir(), 'rerun-data')
-            const rerunScriptPath = join(rerunDataDir, 'rerun.sh')
+            const rerunScriptPath = join(rerunDataDir, rerunScriptFile)
             const service = new RerunService({ rerunDataDir, rerunScriptPath })
             await service.before({}, [])
             service.nonPassingItems = nonPassingItemsMocha
             await service.after()
             await service.onComplete()
+            const disableRerun =
+                platform === 'win32'
+                    ? 'set DISABLE_RERUN=true &&'
+                    : 'DISABLE_RERUN=true'
             const rerunScript = await readFile(rerunScriptPath, 'utf8')
             const parsedArgs = minimist(argv.slice(2))
             const args = parsedArgs._[0] ?? ''
             expect(rerunScript).toBe(
-                `DISABLE_RERUN=true node_modules/.bin/wdio ${args} --spec=tests/sample1.test.ts --spec=tests/sample2.test.ts`,
+                `${disableRerun} npx wdio ${args} --spec=tests/sample1.test.ts --spec=tests/sample2.test.ts`,
             )
             await rm(rerunDataDir, { recursive: true, force: true })
         })


### PR DESCRIPTION
Fixes #30

- use `npx wdio` instead of `node_modules/.bin/wdio`
- make script executable (755)