### PR TITLE
Use correct property when determining framework 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export default class RerunService implements Services.ServiceInstance {
             return
         }
         const { passed } = results
-        const config = browser.config as Options.Testrunner
+        const config = browser.options as Options.Testrunner
         if (passed || config.framework === 'cucumber') {
             return
         }
@@ -99,7 +99,7 @@ export default class RerunService implements Services.ServiceInstance {
         if (this.disabled) {
             return
         }
-        const config = browser.config as Options.Testrunner
+        const config = browser.options as Options.Testrunner
         const status = world.result?.status
         if (
             config.framework !== 'cucumber' ||

--- a/tests/scenario.outline.test.ts
+++ b/tests/scenario.outline.test.ts
@@ -11,7 +11,7 @@ describe('wdio-rerurn-service', () => {
     const specFile = ['tests/scenario.outline.feature']
 
     const cucumberBrowser: WebdriverIO.Browser = {
-        config: { framework: 'cucumber' },
+        options: { framework: 'cucumber' },
     } as WebdriverIO.Browser
 
     it('should generate line number at the row of example data', async () => {

--- a/tests/scenario.test.ts
+++ b/tests/scenario.test.ts
@@ -11,7 +11,7 @@ describe('wdio-rerurn-service', () => {
     const specFile = ['tests/scenario.feature']
 
     const cucumberBrowser: WebdriverIO.Browser = {
-        config: { framework: 'cucumber' },
+        options: { framework: 'cucumber' },
     } as WebdriverIO.Browser
 
     it('should generate line number at the row of scenario', async () => {

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -36,10 +36,10 @@ describe('wdio-rerun-service', () => {
     } satisfies ITestCaseHookParameter
 
     const cucumberBrowser: WebdriverIO.Browser = {
-        config: { framework: 'cucumber' },
+        options: { framework: 'cucumber' },
     } as WebdriverIO.Browser
     const mochaBrowser = {
-        config: { framework: 'mocha' },
+        options: { framework: 'mocha' },
     } as WebdriverIO.Browser
 
     const rerunScriptFile = platform === 'win32' ? 'rerun.bat' : 'rerun.sh'


### PR DESCRIPTION
Addresses #53 

Deprecated browser property was being used, so service was throwing error on an undefined object, preventing hooks from being fully executed to eventually write `rerun.sh`. 