### PR TITLE
ci: Fix "Unsupported engine" error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci --ignore-scripts
@@ -44,7 +44,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci --ignore-scripts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm i -g npm@latest
     - run: npm ci --ignore-scripts
     - run: npm run build --if-present
     - run: npm test
@@ -48,7 +47,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm i -g npm@latest
     - run: npm ci --ignore-scripts
     - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         node-version: [16.x, 18.x]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
@@ -42,7 +42,7 @@ jobs:
       matrix:
         node-version: [16.x]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
### Background

The build is failing because `npm@latest` does not support Node.js v16.
From https://github.com/webdriverio-community/wdio-rerun-service/actions/runs/8117449278/job/22189648193:

```
Run npm i -g npm@latest
  npm i -g npm@latest
  shell: /usr/bin/bash -e {0}
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: npm@10.5.0
npm ERR! notsup Not compatible with your version of node/npm: npm@10.5.0
npm ERR! notsup Required: {"node":"^18.17.0 || >=20.5.0"}
npm ERR! notsup Actual:   {"npm":"8.19.4","node":"v16.20.2"}
```

### Proposed Changes

- ﻿ci: Use a supported version of npm, not `npm@latest`
- ci: Bump actions/checkout from v3 to v4
- ci: Bump actions/setup-node from v3 to v4
